### PR TITLE
Make sidebar navigation arrow point to right when collapsed

### DIFF
--- a/features/layout/sidebar-navigation/menu-item-button.tsx
+++ b/features/layout/sidebar-navigation/menu-item-button.tsx
@@ -9,6 +9,7 @@ type MenuItemProps = {
   iconSrc: string;
   onClick: () => void;
   isCollapsed: boolean;
+  toRotateIcon?: boolean;
 };
 
 export function MenuItemButton({
@@ -17,12 +18,15 @@ export function MenuItemButton({
   onClick,
   iconSrc,
   isCollapsed,
+  toRotateIcon = false,
 }: MenuItemProps) {
+  const iconClass = `${styles.icon} ${toRotateIcon && styles.rotateIcon}`;
+
   return (
     <li className={classNames(styles.listItem, className)}>
       <Button className={styles.anchor} onClick={onClick}>
         {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img className={styles.icon} src={iconSrc} alt={`${text} icon`} />{" "}
+        <img className={iconClass} src={iconSrc} alt={`${text} icon`} />{" "}
         {!isCollapsed && text}{" "}
       </Button>
     </li>

--- a/features/layout/sidebar-navigation/menu-item-link.module.scss
+++ b/features/layout/sidebar-navigation/menu-item-link.module.scss
@@ -30,3 +30,7 @@
   width: space.$s6;
   margin-right: space.$s3;
 }
+
+.rotateIcon {
+  transform: rotate(180deg);
+}

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -89,6 +89,7 @@ export function SidebarNavigation() {
               text="Collapse"
               iconSrc="/icons/arrow-left.svg"
               isCollapsed={isSidebarCollapsed}
+              toRotateIcon={isSidebarCollapsed}
               onClick={() => toggleSidebar()}
               className={styles.collapseMenuItem}
             />


### PR DESCRIPTION
Previously the arrow would always point to the left even when the navigation menu was collapsed.

After:

![image](https://github.com/profydev/prolog-app-iamfranco/assets/23167776/280877ec-6835-49b1-8cf5-d77201625847)
