### PR TITLE
Fix project card separator line thickness to match figma design

### DIFF
--- a/features/projects/components/project-card/project-card.module.scss
+++ b/features/projects/components/project-card/project-card.module.scss
@@ -19,7 +19,7 @@
 
 .bottomContainer {
   padding: space.$s4 space.$s6;
-  border-top: 3px solid color.$gray-200;
+  border-top: 1px solid color.$gray-200;
   display: flex;
   justify-content: flex-end;
 }


### PR DESCRIPTION
Previously the thickness was set to 3px, now changed to 1px to match with figma design

After:
![image](https://github.com/profydev/prolog-app-iamfranco/assets/23167776/340cfb87-857d-46af-9ba8-509537ff299c)
