### PR TITLE
Fix issue list pagination text color, to gray-700 to match figma design

### DIFF
--- a/features/issues/components/issue-list/issue-list.module.scss
+++ b/features/issues/components/issue-list/issue-list.module.scss
@@ -51,7 +51,7 @@
 }
 
 .pageInfo {
-  color: color.$gray-300;
+  color: color.$gray-700;
   font: font.$text-sm-regular;
 }
 


### PR DESCRIPTION
Before:
![image](https://github.com/profydev/prolog-app-iamfranco/assets/23167776/fdb0556b-f781-4711-84f3-7abaef320e45)


After:
![image](https://github.com/profydev/prolog-app-iamfranco/assets/23167776/c7946bc1-84e4-47c8-9026-5541fd0ca82c)
